### PR TITLE
Added check to ensure malloced buffer is non-null prior to use.

### DIFF
--- a/MZAppearance/NSInvocation+Copy.m
+++ b/MZAppearance/NSInvocation+Copy.m
@@ -47,11 +47,13 @@
             NSGetSizeAndAlignment(argumentType, &argumentLength, NULL);
             
             void *buffer = malloc(argumentLength);
+          
+            if (buffer) {
+                [self getArgument:buffer atIndex:index];
+                [invocation setArgument:buffer atIndex:index];
             
-            [self getArgument:buffer atIndex:index];
-            [invocation setArgument:buffer atIndex:index];
-            
-            free(buffer);
+                free(buffer);
+            }
         }
     }
     


### PR DESCRIPTION
Added check for the rare case where a malloc could fail and return NULL as a
result. This is primarily to make a static scan tool happy. This is the same as https://github.com/m1entus/MZAppearance/pull/3, just in a different location.
